### PR TITLE
Add conflicted, dotenv to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,10 @@ Imports:
     readr,
     cli
 Suggests: 
-    drake,
-    capsule
+    conflicted,
+    capsule,
+    dotenv,
+    drake
 Remotes: 
     milesmcbain/fnmate,
     milesmcbain/capsule

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ An opinionated lightweight template for smooth `drake` flows.
 
 ## Installation
 
-`remotes::install_github("milesmcbain/dflow")`
+```r
+remotes::install_github("milesmcbain/dflow")
+```
+
+Set `dependencies = TRUE` to also install [capsule](https://github.com/MilesMcBain/capsule), [conflicted](https://github.com/r-lib/conflicted), [dontenv](https://github.com/gaborcsardi/dotenv), and [drake](https://docs.ropensci.org/drake).
 
 ## Usage
 
 `dflow::use_dflow()`:
 
 ```
-
-
  ./
  |_ R/
  |  |_ plan.R
@@ -20,7 +22,6 @@ An opinionated lightweight template for smooth `drake` flows.
  |_ _drake.R
  |_ packages.R
  |_ .env
-
 ```
 
 `dflow::use_rmd("analysis.Rmd")`:


### PR DESCRIPTION
Hey Miles!

I watched your talk about workflowing last night and one of my favorite bits was how `dflow` lowers the barrier to entry for starting up a drake project. I had heard of `dflow` before but I hadn't realized how minimal it is: it puts the right files in place to just get started and then you can build out from there, which is the style I really like. Feeling like it's going to be _a process_ to set up drake has always been my biggest roadblock to using drake everywhere.

So I fired up `dflow` this morning in the thing I'm working on right now, which happens to be in a docker container where a couple of the recommended packages (conflicted and dotenv) weren't installed. This PR adds them to Suggests and adds a line suggesting to install with `dependencies = TRUE`. I also noticed `git2r` in the Rmd template, but that seems easier to remove and less critical to the workflow.